### PR TITLE
Fix dependencies (#7) and 'ignore_prior' argument

### DIFF
--- a/prospect/kernels/base_kernel.py
+++ b/prospect/kernels/base_kernel.py
@@ -11,6 +11,9 @@ class BaseKernel(ABC):
         self.set_default_errors()
         self.id = task_id
         self.initialise(config_kernel, output_folder)
+        
+        if config_kernel.ignore_prior:
+            self.logprior = lambda x: 0.0
 
         self.param = {
             'varying': {},
@@ -109,7 +112,7 @@ class BaseKernel(ABC):
         pass
 
     def logpost(self, position):
-        return self.loglkl(position)*self.logprior(position)
+        return self.loglkl(position) + self.logprior(position)
 
     @abstractmethod
     def get_default_initial_position(self):
@@ -178,9 +181,15 @@ class Arguments:
         val_type = bool
         def get_default(self, config_yaml: dict[str, Any]):
             return False
+    
+    class ignore_prior(InputArgument):
+        val_type = bool
+        def get_default(self, config_yaml: dict[str, Any]):
+            return False
 
     type: type
     param: param
     conf: conf
     path: path
     debug: debug
+    ignore_prior: ignore_prior

--- a/prospect/profile.py
+++ b/prospect/profile.py
@@ -360,6 +360,3 @@ class Arguments:
     start_from_covmat: start_from_covmat
     start_from_position: start_from_position
     start_from_profile: start_from_profile
-    
-
-

--- a/prospect/tasks/initialise_profile_task.py
+++ b/prospect/tasks/initialise_profile_task.py
@@ -2,7 +2,6 @@ from typing import Type
 from prospect.input import Configuration
 from prospect.tasks.base_task import BaseTask
 from prospect.tasks.initialise_optimiser_task import InitialiseOptimiserTask
-from prospect.tasks.initialise_optimiser_task import InitialiseOptimiserTask
 
 class InitialiseProfileTask(BaseTask):
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "prospect-public"
-version = "24.0.2"
+version = "25.0.0"
 requires-python = ">3.10.0"
 authors = [
   { name="Emil Brinch Holm", email="ebholm@phys.au.dk"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,13 @@ authors = [
   { name="Emil Brinch Holm", email="ebholm@phys.au.dk"},
   { name="Thomas Tram", email="thomas.tram@phys.au.dk"},
 ]
+dependencies = [
+    "numpy>=2.0",
+    "matplotlib>=3.4",
+    "scipy>=1.5",
+    "getdist>=1.3",
+    "PyYAML>=5.1"
+]
 description = "A profile likelihood code for frequentist cosmological parameter inference"
 readme = "README.md"
 classifiers = [


### PR DESCRIPTION
This PR solves #7 and introduces a `ignore_prior` kernel argument, which overrides the kernel `logprior` definition with a uniform prior of constant value 1. Note that this is `False` by default, hence, if one includes non-uniform priors e.g. in a cobaya yaml file, optimisations will find the MAP estimate instead of the maximum likelihood estimate. We leave the default as false since, in my experience, explicit non-uniform priors often come from external empirical constraints (e.g. the ubiquitous BBN prior on omega_b).